### PR TITLE
A style bug of markdown

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ node --harmony compiler-example.js
 
 ### `multicompiler-example.js`
 
-``bash
+```bash
 cd multicompiler-example
 node --harmony multicompiler-example.js
 ```


### PR DESCRIPTION
This line, lost a ` to make it as a right code block

``bash cd multicompiler-example node --harmony multicompiler-example.js